### PR TITLE
fix: correct log build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ hash_data:       view-hash_data
 hash_info:       view-hash_info
 hub:             view-hub
 lex:             view-lex
-logd_data:       view-log_data
-logi_info:       view-log_info
+log_data:        view-log_data
+log_info:        view-log_info
 mmio:            view-mmio
 modexp:          view-modexp_data
 mmu:             view-mmu


### PR DESCRIPTION
## Summary
- fix Makefile targets for `log_data` and `log_info`

## Testing
- `make log_data` *(fails: lualatex: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689472091478832ba2c6792f558a68ca